### PR TITLE
Enable hypothetical positions

### DIFF
--- a/pages/auctions/[auctionId]/buy/index.tsx
+++ b/pages/auctions/[auctionId]/buy/index.tsx
@@ -301,13 +301,14 @@ const BuyCollateral = () => {
                     >
                       <Form.Item name="amountToBuy" required>
                         <TokenAmount
-                          disabled={loading}
                           displayDecimals={4}
                           mainAsset={data?.protocol.name ?? ''}
                           max={maxCredit}
                           maximumFractionDigits={6}
+                          numericInputDisabled={loading}
                           secondaryAsset={data?.underlier.symbol}
                           slider
+                          sliderDisabled={loading}
                         />
                       </Form.Item>
                       <ButtonGradient

--- a/pages/your-positions/[positionId]/manage/index.tsx
+++ b/pages/your-positions/[positionId]/manage/index.tsx
@@ -282,14 +282,15 @@ const PositionManage = () => {
                           />
                           <Form.Item name="deposit" required>
                             <TokenAmount
-                              disabled={formDisabled}
                               displayDecimals={4}
                               healthFactorValue={healthFactor}
                               mainAsset={position.vaultName}
                               max={maxDepositAmount}
                               maximumFractionDigits={6}
+                              numericInputDisabled={formDisabled}
                               secondaryAsset={position.underlier.symbol}
                               slider={'healthFactorVariantReverse'}
+                              sliderDisabled={formDisabled}
                             />
                           </Form.Item>
                         </>
@@ -302,14 +303,15 @@ const PositionManage = () => {
                           />
                           <Form.Item name="withdraw" required>
                             <TokenAmount
-                              disabled={formDisabled}
                               displayDecimals={4}
                               healthFactorValue={healthFactor}
                               mainAsset={position.vaultName}
                               max={maxWithdrawAmount}
                               maximumFractionDigits={6}
+                              numericInputDisabled={formDisabled}
                               secondaryAsset={position.underlier.symbol}
                               slider={'healthFactorVariant'}
+                              sliderDisabled={formDisabled}
                             />
                           </Form.Item>
                         </>
@@ -346,12 +348,13 @@ const PositionManage = () => {
                           />
                           <Form.Item name="mint" required>
                             <TokenAmount
-                              disabled={formDisabled}
                               displayDecimals={contracts.FIAT.decimals}
                               healthFactorValue={healthFactor}
                               max={maxBorrowAmount}
                               maximumFractionDigits={contracts.FIAT.decimals}
+                              numericInputDisabled={formDisabled}
                               slider={'healthFactorVariant'}
+                              sliderDisabled={formDisabled}
                               tokenIcon={<FiatIcon />}
                             />
                           </Form.Item>
@@ -365,12 +368,13 @@ const PositionManage = () => {
                           />
                           <Form.Item name="burn" required>
                             <TokenAmount
-                              disabled={formDisabled}
                               displayDecimals={contracts.FIAT.decimals}
                               healthFactorValue={healthFactor}
                               max={maxRepay}
                               maximumFractionDigits={contracts.FIAT.decimals}
+                              numericInputDisabled={formDisabled}
                               slider={'healthFactorVariantReverse'}
+                              sliderDisabled={formDisabled}
                               tokenIcon={<FiatIcon />}
                             />
                           </Form.Item>

--- a/pages/your-positions/[positionId]/manage/index.tsx
+++ b/pages/your-positions/[positionId]/manage/index.tsx
@@ -286,7 +286,7 @@ const PositionManage = () => {
                               healthFactorValue={healthFactor}
                               mainAsset={position.vaultName}
                               max={maxDepositAmount}
-                              maximumFractionDigits={6}
+                              maximumFractionDigits={4}
                               numericInputDisabled={formDisabled}
                               secondaryAsset={position.underlier.symbol}
                               slider={'healthFactorVariantReverse'}
@@ -307,7 +307,7 @@ const PositionManage = () => {
                               healthFactorValue={healthFactor}
                               mainAsset={position.vaultName}
                               max={maxWithdrawAmount}
-                              maximumFractionDigits={6}
+                              maximumFractionDigits={4}
                               numericInputDisabled={formDisabled}
                               secondaryAsset={position.underlier.symbol}
                               slider={'healthFactorVariant'}

--- a/src/components/custom/token-amount/index.tsx
+++ b/src/components/custom/token-amount/index.tsx
@@ -39,7 +39,7 @@ export type TokenAmountProps = {
 const healthFactorHint =
   'The health factor is a score representing the risk for a given position to be liquidated. ' +
   'A position can be liquidated if the health factor is less than 1.0. ' +
-  'The health factor is derived from the positions ratio between the deposited collateral and the outstanding ' +
+  "The health factor is derived from the position's ratio between the deposited collateral and the outstanding " +
   'debt denominated in FIAT using the following formula: ' +
   'collateral * collateralValue / debt / collateralizationRatio.'
 

--- a/src/components/custom/token-amount/index.tsx
+++ b/src/components/custom/token-amount/index.tsx
@@ -20,7 +20,8 @@ import React, { useState } from 'react'
 
 export type TokenAmountProps = {
   className?: string
-  disabled?: boolean
+  numericInputDisabled?: boolean
+  sliderDisabled?: boolean
   displayDecimals?: number
   hidden?: boolean
   max?: number | BigNumber
@@ -45,7 +46,8 @@ const healthFactorHint =
 const TokenAmount: React.FC<TokenAmountProps> = (props) => {
   const {
     className,
-    disabled = false,
+    numericInputDisabled = false,
+    sliderDisabled = false,
     displayDecimals = 4,
     healthFactorValue = ZERO_BIG_NUMBER,
     hidden,
@@ -117,7 +119,11 @@ const TokenAmount: React.FC<TokenAmountProps> = (props) => {
       <NumericInput
         addonAfter={
           max !== undefined ? (
-            <ButtonOutlineGradient disabled={disabled} onClick={onMaxHandle} textGradient>
+            <ButtonOutlineGradient
+              disabled={numericInputDisabled}
+              onClick={onMaxHandle}
+              textGradient
+            >
               Max
             </ButtonOutlineGradient>
           ) : null
@@ -136,7 +142,7 @@ const TokenAmount: React.FC<TokenAmountProps> = (props) => {
           </div>
         }
         className={cn(s.component, className)}
-        disabled={disabled}
+        disabled={numericInputDisabled}
         hidden={hidden}
         maximumFractionDigits={maximumFractionDigits}
         onChange={handleInputChange}
@@ -183,10 +189,11 @@ const TokenAmount: React.FC<TokenAmountProps> = (props) => {
               {
                 [s.healthFactorVariant]: isHealthFactorVariant,
                 [s.healthFactorVariantReverse]: isHealthFactorVariantReverse,
+                [s.sliderDisabled]: sliderDisabled,
               },
               className,
             )}
-            disabled={disabled}
+            disabled={sliderDisabled}
             max={bnMaxValue.toNumber()}
             min={0}
             onChange={(sliderValue) => {

--- a/src/components/custom/token-amount/s.module.scss
+++ b/src/components/custom/token-amount/s.module.scss
@@ -76,6 +76,22 @@
     }
   }
 
+  &.sliderDisabled {
+    :global(.ant-slider-track) {
+      background-image: none !important;
+      background-color: none !important;
+    }
+
+    :global(.ant-slider-handle) {
+      background: var(--theme-border-color);
+    }
+
+    :global(.ant-slider-handle),
+    &:global(.ant-slider-disabled .ant-slider-handle) {
+      border: 4px solid var(--theme-card-color) !important;
+    }
+  }
+
   &.healthFactorVariantReverse {
     :global(.ant-slider-track),
     &:global(.ant-slider:hover .ant-slider-track) {

--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -35,6 +35,7 @@ export const SET_ALLOWANCE_PROXY_TEXT = 'Set allowance for Proxy'
 export const ENABLE_PROXY_FOR_FIAT_TEXT = 'Enable Proxy for FIAT'
 export const EXECUTE_TEXT = 'Execute'
 export const DEPOSIT_COLLATERAL_TEXT = 'Deposit collateral'
+export const INSUFFICIENT_BALANCE_TEXT = 'Insufficient balance'
 export const EST_FIAT_TOOLTIP_TEXT = `Due to the vault's global
   interest accumulator, the FIAT you receive (send) when borrowing
   (repaying) may be slightly different than what is displayed.`


### PR DESCRIPTION
## Problem
Users can't try out various positions without having fiat/collateral
From community discord..

> it's mildly infuriating that you cannot plug in numbers in the front end  to play with hypothetical values
> I know I have 0 LUSD3CRV
> but please let me see how the app would work IF I HAD

[Link](https://discord.com/channels/888506235224211486/888507756515037204/968523932367990804)

## Solution
Refactor `TokenAmount` component to allow inputs outside the bounds of user's balances or position values.
When the values are outside a range that makes sense, the submit button should be disabled.

fixes #555 