### PR TITLE
Remove element underlier flows from prod

### DIFF
--- a/pages/create-position/[collateralId]/open/index.tsx
+++ b/pages/create-position/[collateralId]/open/index.tsx
@@ -45,7 +45,6 @@ import {
 } from '@/src/web3/utils'
 import { SHOW_UNDERLYING_FLOW } from '@/src/utils/featureFlags'
 import { getDecimalsFromScale } from '@/src/constants/bondTokens'
-import { VaultType } from '@/types/subgraph/__generated__/globalTypes'
 import { useMachine } from '@xstate/react'
 import cn from 'classnames'
 import Lottie from 'lottie-react'
@@ -277,7 +276,7 @@ const FormERC20: React.FC<{
       <div className={cn(s.form)}>
         {[1, 4].includes(activeMachine.context.currentStepNumber) &&
           // Show underlying ui if SHOW_UNDERLYING_FLOW is true. Always show for element
-          (SHOW_UNDERLYING_FLOW || collateral.vault.type == VaultType.ELEMENT) && ( // Feature Flag
+          SHOW_UNDERLYING_FLOW && ( // Feature Flag
             <RadioTabsWrapper className={cn(s.radioTabsWrapper)}>
               <RadioTab
                 checked={tab === CreatePositionTab.asset}

--- a/pages/your-positions/[positionId]/manage/index.tsx
+++ b/pages/your-positions/[positionId]/manage/index.tsx
@@ -25,7 +25,6 @@ import FiatIcon from '@/src/resources/svg/fiat-icon.svg'
 import { Collateral } from '@/src/utils/data/collaterals'
 import { Position } from '@/src/utils/data/positions'
 import { SHOW_UNDERLYING_FLOW } from '@/src/utils/featureFlags'
-import { VaultType } from '@/types/subgraph/__generated__/globalTypes'
 import { SettingFilled } from '@ant-design/icons'
 import AntdForm from 'antd/lib/form'
 import BigNumber from 'bignumber.js'
@@ -267,8 +266,8 @@ const PositionManage = () => {
 
   const shouldShowUnderlyingUi = useMemo(() => {
     // Show underlying ui if SHOW_UNDERLYING_FLOW is true. Always show for element
-    return SHOW_UNDERLYING_FLOW || collateral?.vault.type === VaultType.ELEMENT
-  }, [collateral?.vault.type])
+    return SHOW_UNDERLYING_FLOW
+  }, [])
 
   useEffect(() => {
     // initialize step to 0


### PR DESCRIPTION
Lots of bug reports from underlier flows. Hiding the UI and fixing forward the worst bug reports first (more room for error in reverts)