### PR TITLE
Redeen & withdraw underlier bug fixes

### DIFF
--- a/pages/your-positions/[positionId]/manage/index.tsx
+++ b/pages/your-positions/[positionId]/manage/index.tsx
@@ -447,14 +447,19 @@ const PositionManage = () => {
       </Tab>
     )
 
-    if (isMatured && collateral?.vault.type === VaultType.NOTIONAL) {
-      // If collateral is matured fcash, show only redeem tab
-      return redeemTab
-    } else if (isMatured) {
-      // If matured and not fcash, show all withdraw tabs
-      return shouldShowUnderlyingUi ? [withdrawTab, withdrawUnderlierTab, redeemTab] : [withdrawTab]
+    if (isMatured) {
+      if (collateral?.vault.type === VaultType.NOTIONAL) {
+        // If collateral is notional post-maturity, show only redeem tab
+        return redeemTab
+      } else if (isMatured && shouldShowUnderlyingUi) {
+        // If non-notional & post maturity, and underlier flow off, show withdraw.
+        return withdrawTab
+      } else if (isMatured && !shouldShowUnderlyingUi) {
+        // If non-notional & post maturity, and underlier flow ON, only shouw redeem.
+        return redeemTab
+      }
     } else {
-      // If not matured, show all collateral tabs except redeem tabs
+      // If bond is active (pre-maturity), show all collateral tabs except redeem
       return shouldShowUnderlyingUi
         ? [depositTab, depositUnderlierTab, withdrawTab, withdrawUnderlierTab]
         : [depositTab, withdrawTab]

--- a/pages/your-positions/[positionId]/manage/index.tsx
+++ b/pages/your-positions/[positionId]/manage/index.tsx
@@ -138,11 +138,15 @@ const PositionManage = () => {
     hasTokenAllowance,
     healthFactor,
     isDepositingCollateral,
+    // TODO: use these
+    /* isDepositingUnderlier, */
     isDisabledCreatePosition,
     isLoading,
     isProxyAvailable,
     isRepayingFIAT,
     isWithdrawingCollateral,
+    // TODO: use these
+    /* isWithdrawingUnderlier, */
     loadingFiatAllowanceApprove,
     loadingMonetaAllowanceApprove,
     loadingProxy,

--- a/pages/your-positions/[positionId]/manage/index.tsx
+++ b/pages/your-positions/[positionId]/manage/index.tsx
@@ -291,17 +291,22 @@ const PositionManage = () => {
   }, [activeSection])
 
   useEffect(() => {
+    // @dev NOTE: If you change this, make sure to check the renderCollateralTabs() function
     if (activeSection === 'collateral') {
       if (isMatured) {
         if (collateral?.vault.type === VaultType.NOTIONAL) {
           // expired notional should only show redeem tab, can't be transferred past maturity
+          setActiveTabKey('redeem')
+        } else if (!shouldShowUnderlyingUi) {
+          setActiveTabKey('withdraw')
+        } else if (shouldShowUnderlyingUi) {
           setActiveTabKey('redeem')
         } else if (!isWithdrawCollateralKey(activeTabKey)) {
           setActiveTabKey('withdraw')
         }
       }
     }
-  }, [activeSection, activeTabKey, collateral?.vault.type, isMatured])
+  }, [activeSection, activeTabKey, collateral?.vault.type, isMatured, shouldShowUnderlyingUi])
 
   const getMaturedFCashMessage = useCallback((): string | null => {
     if (position?.protocol === 'Notional Finance' && isMatured) {
@@ -448,13 +453,14 @@ const PositionManage = () => {
     )
 
     if (isMatured) {
+      // @dev NOTE: If you change this, make sure to check the useEffect in this file for setting active section
       if (collateral?.vault.type === VaultType.NOTIONAL) {
         // If collateral is notional post-maturity, show only redeem tab
         return redeemTab
-      } else if (isMatured && shouldShowUnderlyingUi) {
+      } else if (!shouldShowUnderlyingUi) {
         // If non-notional & post maturity, and underlier flow off, show withdraw.
         return withdrawTab
-      } else if (isMatured && !shouldShowUnderlyingUi) {
+      } else if (shouldShowUnderlyingUi) {
         // If non-notional & post maturity, and underlier flow ON, only shouw redeem.
         return redeemTab
       }

--- a/src/hooks/managePosition.tsx
+++ b/src/hooks/managePosition.tsx
@@ -101,6 +101,7 @@ export const useManagePositionForm = (
   const [buttonText, setButtonText] = useState<string>('Execute')
   const tokenAddress = position?.collateral.address
 
+  // Managing fiat tab active section state
   const [isRepayingFIAT, setIsRepayingFIAT] = useState<boolean>(false)
   useEffect(() => {
     // use form values to assume user's intended fiat actions
@@ -121,30 +122,68 @@ export const useManagePositionForm = (
     }
   }, [activeTabKey, positionFormFields?.borrow, positionFormFields?.repay])
 
+  // Managing collateral tab active section state
   const [isDepositingCollateral, setIsDepositingCollateral] = useState<boolean>(false)
+  const [isDepositingUnderlier, setIsDepositingUnderlier] = useState<boolean>(false)
   const [isWithdrawingCollateral, setIsWithdrawingCollateral] = useState<boolean>(false)
+  const [isWithdrawingUnderlier, setIsWithdrawingUnderlier] = useState<boolean>(false)
   useEffect(() => {
     // use form values to assume user's intended fiat actions
     const depositAmount = positionFormFields?.depositAmount
+    const underlierDepositAmount = positionFormFields?.underlierDepositAmount
     const withdrawAmount = positionFormFields?.withdrawAmount
+    const underlierWithdrawAmount = positionFormFields?.underlierWithdrawAmount
     if (depositAmount && depositAmount.gt(ZERO_BIG_NUMBER)) {
       setIsDepositingCollateral(true)
+      setIsDepositingUnderlier(false)
       setIsWithdrawingCollateral(false)
-    } else if (withdrawAmount && withdrawAmount.gt(ZERO_BIG_NUMBER)) {
-      setIsWithdrawingCollateral(true)
+      setIsWithdrawingUnderlier(false)
+    } else if (underlierDepositAmount && underlierDepositAmount.gt(ZERO_BIG_NUMBER)) {
       setIsDepositingCollateral(false)
+      setIsDepositingUnderlier(true)
+      setIsWithdrawingCollateral(false)
+      setIsWithdrawingUnderlier(false)
+    } else if (withdrawAmount && withdrawAmount.gt(ZERO_BIG_NUMBER)) {
+      setIsDepositingCollateral(false)
+      setIsDepositingUnderlier(false)
+      setIsWithdrawingCollateral(true)
+      setIsWithdrawingUnderlier(false)
+    } else if (underlierWithdrawAmount && underlierWithdrawAmount.gt(ZERO_BIG_NUMBER)) {
+      setIsDepositingCollateral(false)
+      setIsDepositingUnderlier(false)
+      setIsWithdrawingCollateral(false)
+      setIsWithdrawingUnderlier(true)
     } else {
+      // if all fields are undefined, assume user's action based on activetab
       if (activeTabKey === 'deposit') {
-        // if all fields are undefined, assume user's action based on activetab
         setIsDepositingCollateral(true)
+        setIsDepositingUnderlier(false)
         setIsWithdrawingCollateral(false)
-      } else if (activeTabKey === 'withdraw') {
-        // if all fields are undefined, assume user's action based on activetab
-        setIsWithdrawingCollateral(true)
+        setIsWithdrawingUnderlier(false)
+      } else if (activeTabKey === 'depositUnderlier') {
         setIsDepositingCollateral(false)
+        setIsDepositingUnderlier(true)
+        setIsWithdrawingCollateral(false)
+        setIsWithdrawingUnderlier(false)
+      } else if (activeTabKey === 'withdraw') {
+        setIsDepositingCollateral(false)
+        setIsDepositingUnderlier(false)
+        setIsWithdrawingCollateral(true)
+        setIsWithdrawingUnderlier(false)
+      } else if (activeTabKey === 'withdrawUnderlier') {
+        setIsDepositingCollateral(false)
+        setIsDepositingUnderlier(false)
+        setIsWithdrawingCollateral(false)
+        setIsWithdrawingUnderlier(true)
       }
     }
-  }, [activeTabKey, positionFormFields?.depositAmount, positionFormFields?.withdrawAmount])
+  }, [
+    activeTabKey,
+    positionFormFields?.depositAmount,
+    positionFormFields?.underlierDepositAmount,
+    positionFormFields?.withdrawAmount,
+    positionFormFields?.underlierWithdrawAmount,
+  ])
 
   const [loadingMonetaAllowanceApprove, setLoadingMonetaAllowanceApprove] = useState<boolean>(false)
 
@@ -833,12 +872,9 @@ export const useManagePositionForm = (
         ]
       : []
 
-    if (activeTabKey === 'underlierDepositAmount' || underlierDepositAmount !== ZERO_BIG_NUMBER) {
+    if (isDepositingUnderlier) {
       return depositUnderlierSummary
-    } else if (
-      activeTabKey === 'underlierWithdrawAmount' ||
-      underlierWithdrawAmount !== ZERO_BIG_NUMBER
-    ) {
+    } else if (isWithdrawingUnderlier) {
       return withdrawUnderlierSummary
     } else if (activeTabKey === 'redeem') {
       return redeemSummary
@@ -883,7 +919,9 @@ export const useManagePositionForm = (
     loadingMonetaAllowanceApprove,
     isRepayingFIAT,
     isDepositingCollateral,
+    isDepositingUnderlier,
     isWithdrawingCollateral,
+    isWithdrawingUnderlier,
   }
 }
 

--- a/src/utils/data/collaterals.ts
+++ b/src/utils/data/collaterals.ts
@@ -24,6 +24,7 @@ export type Collateral = {
   symbol: string
   asset: string
   protocol: string
+  scale: Maybe<string>
   underlierSymbol: Maybe<string>
   underlierAddress: Maybe<string>
   underlierScale: Maybe<string>


### PR DESCRIPTION
## Issue ticket number & link
call redeem correctly for notional & element, only show redeem tab post maturity withdrawal for underlier flow... fixes #674 

also was using technically wrong scale for withdraw underlier oops

## QA Instructions
- [ ] look at non-notional post maturity asset with SHOW_UNDERLIER_FLOW off. confirm your only option is Withdraw
- [x] look at notional post maturity asset with SHOW_UNDERLIER_FLOW off confirm your only option is withdraw
- [ ] look at  post-maturity asset with SHOW_UNDERLIER_FLOW on. confirm your only option is Redeem
- [x] ensure redeem returns you an amount close to what you entered